### PR TITLE
 LIBSEARCH-53. Initial implementation of JSON-LD parse filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,13 @@ logs/
 # Ignore Eclipse metadata files
 .classpath
 .project
+.settings/
 
 # Ignore crawl directory
 LibCrawl/
+
+# Ignore urls/ seed directory
+urls/
 
 # Ignore ivy jar (not sure why this shows up)
 ivy/ivy-2.4.0.jar

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,14 @@ build/
 runtime/
 logs/
 /bin/
+
+# Ignore Eclipse metadata files
+.classpath
+.project
+
+# Ignore crawl directory
+LibCrawl/
+
+# Ignore ivy jar (not sure why this shows up)
+ivy/ivy-2.4.0.jar
+

--- a/README-UMD.md
+++ b/README-UMD.md
@@ -1,0 +1,185 @@
+# Apache Nutch - UMD Customizations
+
+This page provides information about UMD development and customization
+of Apache Nutch.
+
+## Scope of Customizations
+
+The UMD customizations in this repository should only include
+"generic" changes to the official Apache Nutch code.
+
+This will typically be limited to Java source code changes, such as the
+addition of new UMD-specific plugins.
+
+Changes to Nutch configuration files for particular projects should not
+generally be made in this repository. Consider placing project-specific
+configuration changes in the project that uses them, perhaps with an
+associated Dockerfile (see the "Dockerfile-nutch" file in the
+[umd-lib/searchumd][searchumd] application for an example).
+
+## UMD Customizations
+
+See [UmdCustomizations.md](UmdCustomizations.md) for additional
+information about the specific customizations made in this repository.
+
+## Branches and Tags
+
+This project follows the "git flow" branch model described in
+[https://nvie.com/posts/a-successful-git-branching-model/][gitflow],
+with the following changes in branch names:
+
+* develop -> umd-develop
+* master -> umd-master
+
+For tagging, tags should have the form `<UPSTREAM BASE TAG>-umd-<UMD VERSION NUMBER>`
+where the `<UPSTREAM BASE TAG>` corresponds to the Apache Nutch version
+the customizations are based on, and the `<UMD VERSION NUMBER>` is the
+version of the customizations.
+
+## Build Prerequisites
+
+In order to build this project, the Apache Ant must be installed. See
+[http://ant.apache.org/][ant]. On Mac OS X, Ant can be installed via
+Homebrew:
+
+```
+> brew install ant
+```
+
+## Running Nutch
+
+### Running Solr
+
+UMD projects using Nutch are typically configured to assume that an
+Apache Solr instance is running to index the results. 
+
+Using the "searchumd" application as an example,  the following steps
+(drawn from the "Development Setup" section of the README.md in the
+"umd-lib/searchumd" GitHub repository), run a Solr instance in Docker
+so that it is accessible from the host machine:
+
+1) Checkout the "searchumd" GitHub repository and switch into the
+directory:
+
+```
+> git clone https://github.com/umd-lib/searchumd.git
+> cd searchumd
+```
+
+2) Run the following commands to build and run Solr using Docker:
+
+```
+> docker build -t searchumd-solr:dev -f Dockerfile-solr .
+> docker network create dev_network
+> docker run --rm -p 8983:8983 --network dev_network --name solr_app --mount source=solr-data,destination=/opt/solr/server/solr/nutch searchumd-solr:dev
+```
+
+The above commands do the following:
+
+* Creates a Docker network named "dev_network", so that a searchumd
+    application running in Docker can communicate with Solr.
+* The Solr instance is exposed (via the "-p 8983:8983" option) on
+    port 8983 of the localhost, so it is accessible to Nutch (or a
+    searchumd application) running on the host machine.
+* The Solr data is saved in a persistent Docker volume named
+    "solr-data". If you want to run a "clean" instance of Solr, delete
+    the "solr-data" Docker volume before running the Solr container:
+    ```
+    > docker volume rm solr-data
+    ```
+* The Solr should be accessible at [http://localhost:8983/solr][solr]
+
+### Building Nutch
+
+Before building and running Nutch for the first time, copy the Nutch
+configuration files from the associated project into into this
+repository. For example, for the "searchumd" application, and
+assuming that the "searchumd" repository and this repository are
+checked out into the same parent directory, the
+following command will copy the files:
+
+```
+> cp -r ../searchumd/docker_config/nutch/* .
+```
+
+This will copy over the Nutch configuration files, and the "urls"
+directory containing the seed URL to use for the search.
+
+To build Nutch, simply run the "ant" command without any arguments:
+
+```
+> ant
+```
+
+This builds the source code and places an runnable instance of Nutch in
+the runtime/local/ subdirectory.
+
+### Running Nutch
+
+When running Nutch, the URL of the running Solr instance must be
+specified. 
+
+To run Nutch from the root project directory:
+
+```
+> runtime/local/bin/crawl -i -D solr.server.url=http://localhost:8983/solr/nutch -s urls/ LibCrawl/ 2
+```
+
+This will run two crawl iterations, and index the results in the Solr
+instance. The crawl data will be stored in the "LibCrawl/" subdirectory.
+
+## Eclipse Setup
+
+For development work, the project can be set up in Eclipse as follows:
+ 
+### Apache IvyDE plugin
+
+In Eclipse, install the "Apache IvyDE" plugin via the Eclipse
+Marketplace (Help | Eclipse Marketplace...).
+
+### Code Formatting Setup
+
+Set up Eclipse code formatting using the official Apache Nutch
+conventions as follows:
+
+1) In Eclipse, open the "Preferences" dialog by selecting
+"Eclipse | Preferences..." from the menubar (if using the Spring Too
+ Suite version of Eclipse, this will be
+ "Spring Tool Suite | Preferences...")
+ 
+2) In the "Preferences" dialog, select "Java | Code Style | Formatter".
+The "Formatter" pane will be shown on the right side of the dialog.
+ 
+3) In the "Formatter" page, left-click the "Configure Project Specific 
+Settings..." link, and select "nutch" in the resulting dialog. A
+"Properties for nutch" modal dialog will be displayed.
+ 
+4) In the "Properties for nutch" modal dialog, do the following:
+ 
+    a) Left-click the "Enable project specific settings" checkbox.
+ 
+    b) Left-click the "Import..." button. In the resulting file dialog,
+       select the "eclipse-codeformat.xml" file in the project directory.
+ 
+    c) Left-click the "Apply and Close" buttons to close the dialogs.
+ 
+### Importing Nutch into Eclipse
+
+To import the Nutch source code into Eclipse:
+
+1) Run the following command to generate the .classpath and .project
+files needed for Eclipse.
+
+```
+> ant eclipse
+```
+
+2) Run Eclipse, and import the source code using the "File | Import..."
+command, selecting "General | Existing Projects into Workspace" in the
+dialog.
+
+[ant]: http://ant.apache.org/
+[gitflow]: https://nvie.com/posts/a-successful-git-branching-model/
+[searchumd]: https://github.com/umd-lib/searchumd
+[solr]: http://localhost:8983/solr
+

--- a/UmdCustomizations.md
+++ b/UmdCustomizations.md
@@ -1,0 +1,103 @@
+# UMD Customizations
+
+This page provides information about UMD customizations to the official
+Apache Nutch codebase.
+
+## umd-parsefilter-jsonld
+
+A HtmlParseFilter implementation that retrieves JSON-LD scripts from
+web pages, adding selected information from the scripts into the parse
+metadata.
+
+The current implementation looks for a JSON-LD script containing a
+[http://schema.org/WebPage][webpage] object, and extracts the "text"
+value, storing it in a "documentContent" field in the parse content
+metadata.
+
+### Configuration
+
+In keeping with the guidelines indicated in the "Scope of Customizations"
+section in the [README-UMD.md](README-UMD.md), this plugin is not
+configured to run as-is.
+
+The following uses the configuration for the "searchumd" application as
+an example of how to set up the Apache Nutch and Solr configuration
+files to use this plugin.
+
+### Configuring Nutch
+
+To configure Nutch to use "umd-parsefilter-jsonld" plugin:
+
+1) Configure Nutch to use the plugin as part of the parsing step.
+
+The first part simply requires adding the "umd-parsefilter-jsonld"
+plugin to the "plugin.includes" XML stanza in the conf/nutch-site.xml
+file:
+
+```
+<configuration>
+  <property>
+    <name>plugin.includes</name>
+    <value>protocol-http|urlfilter-(regex|validator)|parse-(html|tika)|index-(basic|anchor|metadata)|indexer-solr|scoring-opic|urlnormalizer-(pass|regex|basic)|umd-parsefilter-jsonld</value>
+    ...
+```
+
+(Note the addition of "umd-parsefilter-jsonld" at the end of the "value"
+entry).
+
+2) Configure Nutch to include the "documentContent" field added by this
+plugin to the parse content metadata into the Solr index.
+
+For this part, the "index-metadata" plugin (included in the official
+Apache Nutch release) simply needs to be configured to include the
+"documentContent" from the parse content metadata to the index. To
+do this, add the following to the conf/nutch-site.xml file:
+
+```
+  <property>
+    <name>index.content.md</name>
+    <value>documentContent</value>
+    <description>Comma-separated list of keys to be taken from the content
+    metadata to generate fields.
+    </description>
+  </property>
+```
+
+3) When indexing the Nutch data into Solr, add the following line to the
+"fields" XML stanza in the conf/solrindex-mapping.xml file:
+
+```
+<fields>
+  ...
+  <field dest="documentContent" source="documentContent"/>
+</fields>
+```
+
+This maps the "documentContent" field in Nutch to the "documentContent"
+field in Solr.
+
+### Configuring Solr
+
+In order for Solr to be able to index the "documentContent" field
+provided by this plugin, the Solr "schema.xml" file must be configured
+as follows:
+
+1) Add the "documentContent" field to the "fields" stanza:
+
+```
+<fields>
+  ...
+  <field name="documentContent" type="text_general" stored="true" indexed="true"/>
+  ...
+ </fields>
+ ```
+ 
+ 2) Add the "documentContent" as a "copy" field at the bottom of the
+ file, so that the value is part of the "text" field:
+ 
+ ```
+  <copyField source="documentContent" dest="text"/>
+ ```
+ 
+ [webpage]: http://schema.org/WebPage
+ 

--- a/build.xml
+++ b/build.xml
@@ -996,7 +996,7 @@
 
   <!-- target: ant-eclipse-download   =================================== -->
   <target name="ant-eclipse-download" description="--> downloads the ant-eclipse binary.">
-    <get src="http://downloads.sourceforge.net/project/ant-eclipse/ant-eclipse/1.0/ant-eclipse-1.0.bin.tar.bz2"
+    <get src="https://downloads.sourceforge.net/project/ant-eclipse/ant-eclipse/1.0/ant-eclipse-1.0.bin.tar.bz2"
          dest="${build.dir}/ant-eclipse-1.0.bin.tar.bz2" usetimestamp="false" />
 
     <untar src="${build.dir}/ant-eclipse-1.0.bin.tar.bz2"
@@ -1139,7 +1139,7 @@
         <source path="${plugins.dir}/urlnormalizer-regex/src/test/" />
         <source path="${plugins.dir}/urlnormalizer-slash/src/java/" />
         <source path="${plugins.dir}/urlnormalizer-slash/src/test/" />
-
+        <source path="${plugins.dir}/umd-parsefilter-jsonld/src/java/" />
         <output path="${build.classes}" />
       </classpath>
     </eclipse>

--- a/src/plugin/build.xml
+++ b/src/plugin/build.xml
@@ -98,6 +98,7 @@
     <ant dir="urlnormalizer-querystring" target="deploy"/>
     <ant dir="urlnormalizer-regex" target="deploy"/>
     <ant dir="urlnormalizer-slash" target="deploy"/>
+    <ant dir="umd-parsefilter-jsonld" target="deploy"/>
   </target>
   
   <!-- ====================================================== -->
@@ -223,5 +224,6 @@
     <ant dir="urlnormalizer-querystring" target="clean"/>
     <ant dir="urlnormalizer-regex" target="clean"/>
     <ant dir="urlnormalizer-slash" target="clean"/>
+    <ant dir="umd-parsefilter-jsonld" target="clean"/>
   </target>
 </project>

--- a/src/plugin/umd-parsefilter-jsonld/build.xml
+++ b/src/plugin/umd-parsefilter-jsonld/build.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<project name="umd-parsefilter-jsonld" default="jar-core">
+
+  <import file="../build-plugin.xml"/>
+
+   <!-- Add compilation dependencies to classpath -->
+   <path id="plugin.deps">
+   	 <!-- parse-html is used for the "main" method -->
+     <fileset dir="${nutch.root}/build">
+       <include name="**/parse-html/*.jar" />
+      </fileset>
+    </path>
+</project>

--- a/src/plugin/umd-parsefilter-jsonld/ivy.xml
+++ b/src/plugin/umd-parsefilter-jsonld/ivy.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<ivy-module version="1.0">
+  <info organisation="org.apache.nutch" module="${ant.project.name}">
+    <license name="Apache 2.0"/>
+    <ivyauthor name="Apache Nutch Team" url="http://nutch.apache.org"/>
+    <description>
+        Apache Nutch
+    </description>
+  </info>
+
+  <configurations>
+    <include file="../../../ivy/ivy-configurations.xml"/>
+  </configurations>
+
+  <publications>
+    <!--get the artifact from our module name-->
+    <artifact conf="master"/>
+  </publications>
+
+  <dependencies>
+    <dependency org="com.github.mautini" name="schemaorg-java" rev="1.0.1" />   
+  </dependencies>
+</ivy-module>

--- a/src/plugin/umd-parsefilter-jsonld/plugin.xml
+++ b/src/plugin/umd-parsefilter-jsonld/plugin.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<plugin
+   id="umd-parsefilter-jsonld"
+   name="UMD Html Parse Filter JSON-LD Plug-in"
+   version="1.0.0"
+   provider-name="ssdr">
+
+   <runtime>
+      <library name="umd-parsefilter-jsonld.jar">
+         <export name="*"/>
+      </library>
+      <library name="schemaorg-java-1.0.1.jar"/>
+   </runtime>
+
+   <requires>
+      <import plugin="nutch-extensionpoints"/>
+   </requires>
+
+   <extension id="edu.umd.lib.parsefilter.jsonld"
+        name="Nutch Parser Filter" point="org.apache.nutch.parse.HtmlParseFilter">
+      <implementation id="UmdJsonLdParseFilter" 
+        class="edu.umd.lib.parsefilter.jsonld.UmdJsonLdParseFilter"/>
+   </extension>
+ </plugin>

--- a/src/plugin/umd-parsefilter-jsonld/src/java/edu/umd/lib/parsefilter/jsonld/UmdJsonLdParseFilter.java
+++ b/src/plugin/umd-parsefilter-jsonld/src/java/edu/umd/lib/parsefilter/jsonld/UmdJsonLdParseFilter.java
@@ -1,0 +1,120 @@
+package edu.umd.lib.parsefilter.jsonld;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.nutch.metadata.Metadata;
+import org.apache.nutch.parse.HTMLMetaTags;
+import org.apache.nutch.parse.HtmlParseFilter;
+import org.apache.nutch.parse.Parse;
+import org.apache.nutch.parse.ParseResult;
+import org.apache.nutch.protocol.Content;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.DocumentFragment;
+
+import com.google.schemaorg.JsonLdSerializer;
+import com.google.schemaorg.JsonLdSyntaxException;
+import com.google.schemaorg.SchemaOrgType;
+import com.google.schemaorg.core.Thing;
+import com.google.schemaorg.core.WebPage;
+import com.google.schemaorg.core.datatype.Text;
+
+/**
+ * Filters the raw HTML for JSON-LD scripts, adding selected information
+ * from the scripts into the parse metadata.
+ */
+public class UmdJsonLdParseFilter implements HtmlParseFilter {
+  private static final Logger LOG = LoggerFactory
+      .getLogger(MethodHandles.lookup().lookupClass());
+
+  /**
+   * Pattern used to extract JSON-LD scripts from HTML
+   */
+  private static final Pattern JSON_LD_SCRIPT_PATTERN = Pattern.compile(
+      ".*<script type=\\\"application\\/ld\\+json\\\">(.*?)</script>.*",
+      Pattern.DOTALL);
+
+  private Configuration conf;
+
+  public UmdJsonLdParseFilter() {
+  }
+
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+  }
+
+  public Configuration getConf() {
+    return this.conf;
+  }
+
+  /**
+   * Extracts JSON-LD scripts from the HTML, and populates metadata with
+   * selected JSON-LD information.
+   */
+  @Override
+  public ParseResult filter(Content content, ParseResult parseResult,
+      HTMLMetaTags metaTags, DocumentFragment doc) {
+
+    Parse parse = parseResult.get(content.getUrl());
+    String rawHtml = new String(content.getContent());
+
+    Metadata metadata = parse.getData().getContentMeta();
+    extractJsonLd(rawHtml, metadata);
+
+    return parseResult;
+  }
+
+  /**
+   * Extract JSON-LD scripts from the provided HTML, populating the
+   * provided Metadata with information from the JSON-LD.
+   * 
+   * @param html
+   *          the raw HTML of the web page
+   * @param metadata
+   *          the Metadata object to populate with JSON-LD data.
+   */
+  private void extractJsonLd(String html, Metadata metadata) {
+    Pattern p = JSON_LD_SCRIPT_PATTERN;
+    Matcher m = p.matcher(html);
+
+    List<String> jsonLdMatches = new ArrayList<>();
+
+    while (m.find()) {
+      jsonLdMatches.add(m.group(1));
+    }
+
+    for (String jsonLdString : jsonLdMatches) {
+      try {
+        JsonLdSerializer serializer = new JsonLdSerializer(true);
+        List<Thing> actual = serializer.deserialize(jsonLdString);
+        Thing firstThing = actual.get(0);
+
+        // For WebPage objects, store "text" in the metadata
+        if ("http://schema.org/WebPage".equals(firstThing.getFullTypeName())) {
+          WebPage webPage = (WebPage) firstThing;
+          List<SchemaOrgType> textList = webPage.getTextList();
+          if (textList.size() > 0) {
+            Text text = (Text) textList.get(0);
+            String webPageText = text.getValue();
+
+            // Ignore text that is all whitespace, empty, or null.
+            if (!StringUtils.isBlank(webPageText)) {
+              // Trim whitespace, because some documents have opening/trailing
+              // spaces
+              metadata.add("documentContent", webPageText.trim());
+              break;
+            }
+          }
+        }
+      } catch (JsonLdSyntaxException jse) {
+        LOG.error("Error parsing JSON-LD", jse);
+      }
+    }
+  }
+}

--- a/src/plugin/umd-parsefilter-jsonld/src/java/edu/umd/lib/parsefilter/jsonld/package.html
+++ b/src/plugin/umd-parsefilter-jsonld/src/java/edu/umd/lib/parsefilter/jsonld/package.html
@@ -1,0 +1,12 @@
+<html>
+  <body>
+    <p>
+      An HTML parsing filter that retrieves JSON-LD scripst from
+      web pages, adding selected information from the scripts into the
+      parse metadata.
+    </p>
+    <p>
+      This package relies on <a href="https://github.com/mautini/schemaorg-java">schemaorg-java</a>.
+    </p>
+</body>
+</html>


### PR DESCRIPTION
Initial implementation of a JSON-LD parse filter plugin for Apache
Nutch.

When parsing web pages, the HTML is searched for JSON-LD scripts,
and if one of the script contains a "WebPage" object, the "text" value
of the object is placed in the "documentContent" field of the parse
content metadata.

Note: This plugin is not enabled by default, and no Nutch configuration
files have been changed. See the docker_config/nutch/ subdirectory in
the "searchumd" application for the relevant configuration files.

https://issues.umd.edu/browse/LIBSEARCH-53