### PR TITLE
LIBSEARCH-169. Skip JSON-LD processing on PDF files.

### DIFF
--- a/src/plugin/umd-parsefilter-jsonld/src/java/edu/umd/lib/parsefilter/jsonld/UmdJsonLdParseFilter.java
+++ b/src/plugin/umd-parsefilter-jsonld/src/java/edu/umd/lib/parsefilter/jsonld/UmdJsonLdParseFilter.java
@@ -60,6 +60,13 @@ public class UmdJsonLdParseFilter implements HtmlParseFilter {
   @Override
   public ParseResult filter(Content content, ParseResult parseResult,
       HTMLMetaTags metaTags, DocumentFragment doc) {
+    // Skip non-HTML files, as it may cause parsing to hang, and only
+    // HTML files are relevant anyway.
+    String contentType = content.getContentType();
+    if (!"text/html".equals(contentType)) {
+      LOG.debug("Skipping processing of '" + contentType + "' document");
+      return parseResult;
+    }
 
     Parse parse = parseResult.get(content.getUrl());
     String rawHtml = new String(content.getContent());


### PR DESCRIPTION
Modified umd-parse-filter-jsonld plugin to no process PDF files,
as it causes the parser to hang.

https://issues.umd.edu/browse/LIBSEARCH-169